### PR TITLE
Switch from os-shade to os_openstacksdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - ln -s ansible-role-os-volumes/ ../os-volumes
 
   # Install galaxy role dependencies.
-  - ansible-galaxy install -p .. stackhpc.os-shade stackhpc.os-openstackclient
+  - ansible-galaxy install -p .. stackhpc.os_openstacksdk stackhpc.os-openstackclient
 
 script:
   # Basic role syntax check

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ dict containing the following items:
 Dependencies
 ------------
 
-This role depends on the `stackhpc.os-shade` role.
+This role depends on the `stackhpc.os_openstacksdk` role.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# Path to virtualenv in which to install shade and its dependencies.
+# Path to virtualenv in which to install openstacksdk and its dependencies.
 os_volumes_venv:
 
 # Authentication type compatible with the 'os_volume' Ansible module's

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
     - openstack
 
 dependencies:
-  - role: stackhpc.os-shade
-    os_shade_venv: "{{ os_volumes_venv }}"
+  - role: stackhpc.os_openstacksdk
+    os_openstacksdk_venv: "{{ os_volumes_venv }}"
   - role: stackhpc.os-openstackclient
     os_openstackclient_venv: "{{ os_volumes_venv }}"


### PR DESCRIPTION
Shade is no longer required by ansible modules.